### PR TITLE
fix: update events for 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,21 +79,17 @@
                                     </p>
 
                                     <p>
-                                    <h4>2024 Overview</h4>
+                                    <h4>2025 Overview</h4>
                                     <ul>
                                         <li>January - Winter Blast / Merit Badge University @ Camp Durant</li>
                                         <li>February - Shooting Sports @ Camp Durant</li>
-                                        <li>March - Battleship NC & Camping @ Carolina Beach State Park</li>
-                                        <li>April - Backpacking @ Uwharrie National Forest</li>
-                                        <li>May - Tubing Adventure on the Neuse River</li>
-                                        <li>June - Camping, Hiking, & Snorkeling @ Cave Mountain, VA</li>
-                                        <li>July - Summer Camp @ Camp Shenandoah</li>
-                                        <li>July - High Adventure: Sailing @ Sea Base</li>
-                                        <li>August - Pool Party!</li>
-                                        <li>September - Camping & Swimming @ Sliding Rock</li>
-                                        <li>October - Biking & Camping @ Virginia Capitol Trail and Jamestown</li>
-                                        <li>November - Canoeing & Camping @ Dismal Swamp</li>
-                                        <li>And more planned for 2025 including Winter Blast, Range & Target activities, and Summit High Adventure! </li>
+                                        <li>March - One Night Flop & Drop @ Raleigh Elks Lodge</li>
+                                        <li>April - Camping, Hiking, and History @ Appomatix Court House Historic National Park, VA</li>
+                                        <li>May - Wings Over Wayne @ Goldsboro, NC</li>
+                                        <li>June - Backpacking @ Mount Rogers & Grayson Highlands, VA</li>
+                                        <li>July - Summer Camp @ Camp John J. Barnhardt</li>
+                                        <li>July - High Adventure @ Summit Experience</li>
+                                        <li>And more being planned for 2025!</li>
                                     </ul>
                                     </p>
 


### PR DESCRIPTION
- updates the 2024 highlights for 2025
- there are no campouts planned post-august, so those are left off (although they will be added as they are planned)